### PR TITLE
Fix README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ First, create the PDLJS client:
 ```js
 import PDLJS from 'peopledatalabs';
 
-PDLJSClient = PDLJS({“apiKey”: “YOUR API KEY”})
+const PDLJSClient = new PDLJS({apiKey: "YOUR API KEY"})
 ```
 
 Then, send requests to any PDL API Endpoint:


### PR DESCRIPTION
The README example is incorrectly missing the `new` keyword for instantiating the `PDLJS` class. Caused me a lot of headaches until I found out! Hope it can help others.