### PR TITLE
fix(enrich): Allow array of params

### DIFF
--- a/src/endpoints/enrichment/index.ts
+++ b/src/endpoints/enrichment/index.ts
@@ -20,21 +20,27 @@ export default <T extends PersonEnrichmentParams | CompanyEnrichmentParams, K ex
 
     const url = params.sandbox && type === 'person' ? `${sandboxBasePath}/${type}/enrich` : `${basePath}/${type}/enrich`;
 
-    const p = params;
-    delete p.sandbox;
+    const p = new URLSearchParams();
+    delete params.sandbox;
 
-    Object.entries(p).forEach(([key, value]) => {
+    Object.entries(params).forEach(([key, value]) => {
       if (typeof value === 'object') {
-        // @ts-ignore
-        p[key] = JSON.stringify(value);
+        if (Array.isArray(value)) {
+          value.forEach(member => {
+            p.append(key, (member));
+          })
+        } else {
+          p.append(key, JSON.stringify(value));
+        }
+      } else {
+        p.append(key, (value));
       }
     });
 
+    p.append("api_key", apiKey);
+
     axios.get<K>(url, {
-      params: {
-        api_key: apiKey,
-        ...p,
-      },
+      params: p,
       headers,
     })
       .then((response) => {


### PR DESCRIPTION
## Description of the change

This change updates the library to handle correct passing of array parameters to the URL. For example, if you were to pass email as an array, it would be encoded as &email=["email1", "email2"] as opposed to &email=email1&email=email2. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
