### PR TITLE
Add strict typechecking with v23 retrieve filters

### DIFF
--- a/src/endpoints/bulkRetrieve/index.ts
+++ b/src/endpoints/bulkRetrieve/index.ts
@@ -1,8 +1,28 @@
 import axios from 'axios';
 
 import { check, errorHandler } from '../../errors';
-import { BulkPersonRetrieveParams, BulkPersonRetrieveResponse } from '../../types/bulk-retrieve-types';
+import {
+  ApiBulkPersonRetrieveParams,
+  BulkPersonRetrieveParams,
+  BulkPersonRetrieveResponse
+} from '../../types/bulk-retrieve-types';
 import { parseRateLimitingResponse } from '../../utils/api-utils';
+
+const transformBulkRetrieveParams = (params: BulkPersonRetrieveParams): ApiBulkPersonRetrieveParams => {
+  const filter = params.filter_updated;
+  if (filter == null) {
+    return {
+      ...params,
+      filter_updated: undefined,
+    };
+  }
+  const filtersArray = Array.isArray(filter) ? filter : [filter];
+  const filterUpdated = filtersArray.join(',');
+  return {
+    ...params,
+    filter_updated: filterUpdated,
+  };
+};
 
 export default (basePath: string, apiKey: string, records: BulkPersonRetrieveParams) => {
   const headers = {
@@ -14,7 +34,8 @@ export default (basePath: string, apiKey: string, records: BulkPersonRetrievePar
 
   return new Promise<BulkPersonRetrieveResponse>((resolve, reject) => {
     check(records, basePath, apiKey, 'Records', 'bulk').then(() => {
-      axios.post<BulkPersonRetrieveResponse>(`${basePath}/person/retrieve/bulk`, records, { headers })
+      const apiParams = transformBulkRetrieveParams(records);
+      axios.post<BulkPersonRetrieveResponse>(`${basePath}/person/retrieve/bulk`, apiParams, { headers })
         .then((response) => {
           resolve(parseRateLimitingResponse(response));
         })

--- a/src/endpoints/retrieve/index.ts
+++ b/src/endpoints/retrieve/index.ts
@@ -1,8 +1,28 @@
 import axios from 'axios';
 
 import { check, errorHandler } from '../../errors';
-import { RetrieveParams, RetrieveResponse } from '../../types/retrieve-types';
+import {
+  ApiRetrieveParams,
+  RetrieveParams,
+  RetrieveResponse,
+} from '../../types/retrieve-types';
 import { parseRateLimitingResponse } from '../../utils/api-utils';
+
+const transformRetrieveParams = (params: RetrieveParams): ApiRetrieveParams => {
+  const filter = params.filter_updated;
+  if (filter == null) {
+    return {
+      ...params,
+      filter_updated: undefined,
+    };
+  }
+  const filtersArray = Array.isArray(filter) ? filter : [filter];
+  const filterUpdated = filtersArray.join(',');
+  return {
+    ...params,
+    filter_updated: filterUpdated,
+  };
+};
 
 export default (
   basePath: string,
@@ -14,11 +34,12 @@ export default (
       'Accept-Encoding': 'gzip',
       'User-Agent': 'PDL-JS-SDK',
     };
+    const apiParams = transformRetrieveParams(params);
 
     axios.get<RetrieveResponse>(`${basePath}/person/retrieve/${params.id}`, {
       params: {
         api_key: apiKey,
-        ...params,
+        ...apiParams,
       },
       headers,
     })

--- a/src/types/bulk-retrieve-types.ts
+++ b/src/types/bulk-retrieve-types.ts
@@ -1,17 +1,18 @@
 import { BaseResponse, RateLimit } from './api-types';
 import { PersonResponse } from './common-types';
+import { ApiRetrieveMetaParams, RetrieveMetaParams } from './retrieve-types';
 
 export type BulkPersonRetrieveRequest = {
   id: string;
   metadata?: unknown;
 };
 
-export interface BulkPersonRetrieveParams {
-  requests: Array<BulkPersonRetrieveRequest> & {
-    pretty?: boolean;
-    titlecase?: boolean;
-    filter_updated?: 'job_change' | any;
-  }
+export interface BulkPersonRetrieveParams extends RetrieveMetaParams {
+  requests: Array<BulkPersonRetrieveRequest>;
+}
+
+export interface ApiBulkPersonRetrieveParams extends ApiRetrieveMetaParams {
+  requests: Array<BulkPersonRetrieveRequest>;
 }
 
 export interface BulkPersonRetrieveResponseItem extends BaseResponse {
@@ -20,7 +21,7 @@ export interface BulkPersonRetrieveResponseItem extends BaseResponse {
   billed: boolean;
 }
 
-// This response does extend from the BaseResponse since each item in the array has its own status
+// This response does not extend from the BaseResponse since each item in the array has its own status
 // See https://docs.peopledatalabs.com/docs/bulk-requests
 export type BulkPersonRetrieveResponse = {
   items: Array<BulkPersonRetrieveResponseItem>,

--- a/src/types/retrieve-types.ts
+++ b/src/types/retrieve-types.ts
@@ -1,13 +1,27 @@
 import { BaseResponse } from './api-types';
 import { PersonResponse } from './common-types';
 
-export type RetrieveParams = {
-  id: string;
-} & {
+export type RetrieveFilter = 'job_change' | 'education' | 'location' | 'personal_emails' | 'phone_number' | 'social_profile' | 'work_email';
+
+export type RetrieveMetaParams = {
   pretty?: boolean;
   titlecase?: boolean;
-  filter_updated?: 'job_change' | any;
+  filter_updated?: RetrieveFilter | RetrieveFilter[];
 };
+
+export type ApiRetrieveMetaParams = {
+  pretty?: boolean;
+  titlecase?: boolean;
+  filter_updated?: string;
+};
+
+export type RetrieveParams = {
+  id: string;
+} & RetrieveMetaParams;
+
+export type ApiRetrieveParams = {
+  id: string;
+} & ApiRetrieveMetaParams;
 
 export interface RetrieveResponse extends BaseResponse {
   data: PersonResponse


### PR DESCRIPTION
## Description of the change

Updates type for `filter_updated` to strictly check for [v23 types](https://docs.peopledatalabs.com/docs/input-parameters-person-retrieve-api).

I'm marking this as a breaking change since the shape of params for bulk retrieve is changing (and there's strict typechecking on filter strings). That said, I am not sure `pretty`, `titlecase`, `filter_updated` work as it's currently written.

### Previous definition
```
export interface BulkPersonRetrieveParams {
  requests: Array<BulkPersonRetrieveRequest> & {
    pretty?: boolean;
    titlecase?: boolean;
    filter_updated?: 'job_change' | any;
  }
}
```

This seems to be an object with a single field, `requests`, where requests is an array with additional metadata. The code sample [here](https://docs.peopledatalabs.com/docs/bulk-person-retrieve#tracking-responses) seems to imply that the additional fields should be siblings of `requests`.

```
# Create a parameters JSON object with an array of person IDs
BODY = {
    "requests": [
        {
            "id": "qEnOZ5Oh0poWnQ1luFBfVw_0000",
            # Include metadata object
            "metadata": {
                "user_id": 123
            },
        },
        {
            "id": "PzFD15NINdBWNULBBkwlig_0000",
            # Include metadata object
            "metadata": {
                "user_id": 569
            },
        },
    ],
    "pretty": True,
    "titlecase": True,
}
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
