### PR TITLE
Include rate limit information on errors

### DIFF
--- a/src/types/error-types.ts
+++ b/src/types/error-types.ts
@@ -1,1 +1,9 @@
+import { RateLimit } from './api-types';
+
 export type ErrorEndpoint = 'enrichment' | 'autocomplete' | 'search' | 'identify' | 'bulk' | 'cleaner' | 'retrieve' | 'jobTitle' | 'skill' | 'ip';
+
+export type PdlError = {
+  message: string;
+  status: number;
+  rateLimit?: RateLimit;
+};


### PR DESCRIPTION
## Description of the change

Without including rate limit information on errors, it's hard to determine the correct time to wait until making the next request after a `429` error.

A user currently has a few options:
1. Retry with exponential backoff, which will likely hit the API a few times before the rate limit window reset
2. Wait a full 60 seconds to be "safe", not an efficient use of resources
3. ~Assume that rate limit windows from PDL will always be reset at the top of the minute (maybe this is a safe assumption?)~ Looks like sample [here](https://docs.peopledatalabs.com/docs/usage-limits#sample-response-headers) shows this is not true (`"x-ratelimit-reset": "2022-02-23T20:19:55Z"`).

With rate limit information included on errors, the user can wait until the reset time. PDL can change their rate limit window logic, and user code will adapt appropriately.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
