### PR TITLE
Add matched type in PersonEnrichmentResponse interface

### DIFF
--- a/src/types/enrichment-types.ts
+++ b/src/types/enrichment-types.ts
@@ -43,7 +43,8 @@ export type PersonEnrichmentParams = EnrichmentAdditionalParams & Partial<{
 
 export interface PersonEnrichmentResponse extends BaseResponse {
   likelihood: number,
-  data: PersonResponse
+  data: PersonResponse,
+  matched: Array<string>
 }
 
 export type PersonEnrichmentPreviewParams = PersonEnrichmentParams;


### PR DESCRIPTION
## Description of the change

- Update the PersonEnrichmentResponse interface by adding "matched" type, because person enrichment api returns matched array of strings when passed a param 'include_if_matched: true' and it's type was not proper in the sdk and I was unable to destructure "matched" or use it like response.matched in typescript.

https://docs.peopledatalabs.com/docs/output-response-person-enrichment-api#matched

![Screenshot from 2024-04-23 20-06-38](https://github.com/peopledatalabs/peopledatalabs-js/assets/62418589/bab1b9b3-82cf-45dc-ac13-931ca49a98ac)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
