### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Fix for [https://github.com/peopledatalabs/peopledatalabs-js/security/code-scanning/1](https://github.com/peopledatalabs/peopledatalabs-js/security/code-scanning/1)

To fix the issue, we need to explicitly define a `permissions` block for the `test` job. Since the `test` job only runs tests and does not require write access, we can set the permissions to `contents: read`. This ensures that the job has the minimal permissions required to execute its tasks, adhering to the principle of least privilege.