### PR TITLE
move @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "homepage": "https://docs.peopledatalabs.com/docs/javascript-sdk",
   "devDependencies": {
     "@stylistic/eslint-plugin": "^3.1.0",
+    "@types/chai": "^5.2.3",
+    "@types/mocha": "^10.0.10",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "chai": "^6.2.2",
@@ -71,8 +73,6 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@types/chai": "^5.2.3",
-    "@types/mocha": "^10.0.10",
     "axios": "^1.13.2",
     "copy-anything": "3.0.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@types/chai':
-        specifier: ^5.2.3
-        version: 5.2.3
-      '@types/mocha':
-        specifier: ^10.0.10
-        version: 10.0.10
       axios:
         specifier: ^1.13.2
         version: 1.13.2
@@ -24,6 +18,12 @@ importers:
       '@stylistic/eslint-plugin':
         specifier: ^3.1.0
         version: 3.1.0(eslint@8.57.1)(typescript@5.9.3)
+      '@types/chai':
+        specifier: ^5.2.3
+        version: 5.2.3
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       '@typescript-eslint/eslint-plugin':
         specifier: 7.18.0
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)


### PR DESCRIPTION
## Description of the change

- Moves @types/chai and @types/mocha from dependencies to devDependencies so that downstream consumers don't need to install them

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
