### PR TITLE
chore: version 14.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [14.4.0] - 2026-07-22
+
+- Added technologies_used to Company response type (PDL API v35.0)
+
 ## [14.3.0] - 2026-06-11
 
 - Added new job posting endpoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peopledatalabs",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "JavaScript client with TypeScript support for the People Data Labs API",
   "packageManager": "pnpm@10.27.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump package version to 14.4.0
- Add CHANGELOG entry for v35.0 `technologies_used` field on Company response

## Test plan
- [x] `pnpm test` passes (54 passing)